### PR TITLE
Changed 'compile' to 'implementation'

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ repositories {
 And finnaly add this line inside `dependencies { }` section:
 
 ```gradle
-compile 'com.github.fernandodev.androidproperties:androidproperties:+'
+implementation 'com.github.fernandodev.androidproperties:androidproperties:+'
 ```
 
 The `+` symbol indicates to gradle to get the latest version.


### PR DESCRIPTION
Compile is obsolete and has been replaced with 'implementation'. It will be removed at the end of 2018.